### PR TITLE
MAINT: use inst_id

### DIFF
--- a/pysatIncubator/instruments/champ_star.py
+++ b/pysatIncubator/instruments/champ_star.py
@@ -11,7 +11,7 @@ name
     'star'
 tag
     None supported
-sat_id
+inst_id
     None supported
 
 
@@ -37,7 +37,7 @@ import pysat
 platform = 'champ'
 name = 'star'
 tags = {'': ''}
-sat_ids = {'': ['']}
+inst_ids = {'': ['']}
 _test_dates = {'': {'': dt.datetime(2007, 1, 1)}}
 _test_download = {'': {'': False}}
 
@@ -60,7 +60,7 @@ def init(self):
     return
 
 
-def list_files(tag='', sat_id=None, data_path=None, format_str=None):
+def list_files(tag='', inst_id=None, data_path=None, format_str=None):
     """Return a Pandas Series of every file for chosen satellite data
 
     Parameters
@@ -69,7 +69,7 @@ def list_files(tag='', sat_id=None, data_path=None, format_str=None):
         Denotes type of file to load.  Accepted types are '' and 'ascii'.
         If '' is specified, the primary data type (ascii) is loaded.
         (default='')
-    sat_id : string or NoneType
+    inst_id : string or NoneType
         Specifies the satellite ID for a constellation.  Not used.
         (default=None)
     data_path : string or NoneType
@@ -100,7 +100,7 @@ def list_files(tag='', sat_id=None, data_path=None, format_str=None):
         return pysat.Files.from_os(data_path=data_path, format_str=format_str)
 
 
-def load(fnames, tag=None, sat_id=None):
+def load(fnames, tag=None, inst_id=None):
     """Load CHAMP STAR files
 
     Parameters
@@ -109,7 +109,7 @@ def load(fnames, tag=None, sat_id=None):
         Series of filenames
     tag : str or NoneType
         tag or None (default=None)
-    sat_id : str or NoneType
+    inst_id : str or NoneType
         satellite id or None (default=None)
 
     Returns
@@ -217,7 +217,7 @@ def load(fnames, tag=None, sat_id=None):
     return data, meta
 
 
-def download(date_array, tag, sat_id, data_path, user=None, password=None):
+def download(date_array, tag, inst_id, data_path, user=None, password=None):
     """Routine to download CHAMP STAR data
 
     Parameters

--- a/pysatIncubator/instruments/demeter_iap.py
+++ b/pysatIncubator/instruments/demeter_iap.py
@@ -23,7 +23,7 @@ name
     'iap'
 tag
     'survey' or 'burst'
-sat_id
+inst_id
     None supported
 
 Example
@@ -60,7 +60,7 @@ platform = 'demeter'
 name = 'iap'
 tags = {'survey': 'Survey mode',
         'burst': 'Burst mode'}
-sat_ids = {'': list(tags.keys())}
+inst_ids = {'': list(tags.keys())}
 _test_dates = {'': {'survey': dt.datetime(2010, 1, 1)}}
 _test_download = {'': {kk: False for kk in tags.keys()}}
 
@@ -84,7 +84,7 @@ def init(self):
     return
 
 
-def list_files(tag="survey", sat_id='', data_path=None, format_str=None,
+def list_files(tag="survey", inst_id='', data_path=None, format_str=None,
                index_start_time=True):
     """Return a Pandas Series of every file for DEMETER IAP satellite data
 
@@ -93,7 +93,7 @@ def list_files(tag="survey", sat_id='', data_path=None, format_str=None,
     tag : string
         Denotes type of file to load.  Accepted types are 'survey'; 'burst'
         will be added in the future.  (default='survey')
-    sat_id : string or NoneType
+    inst_id : string or NoneType
         Specifies the satellite ID for a constellation.  Not used.
         (default='')
     data_path : string or NoneType
@@ -128,7 +128,7 @@ def list_files(tag="survey", sat_id='', data_path=None, format_str=None,
     return pysat.Files.from_os(data_path=data_path, format_str=format_str)
 
 
-def load(fnames, tag='survey', sat_id=''):
+def load(fnames, tag='survey', inst_id=''):
     """ Load DEMETER IAP data
 
     Parameters
@@ -138,7 +138,7 @@ def load(fnames, tag='survey', sat_id=''):
     tag : string
         Denotes type of file to load.  Accepted types are 'survey'; 'burst'
         will be added in the future.  (default='survey')
-    sat_id : string or NoneType
+    inst_id : string or NoneType
         Specifies the satellite ID for a constellation.  Not used.
         (default='')
 

--- a/pysatIncubator/instruments/methods/demeter.py
+++ b/pysatIncubator/instruments/methods/demeter.py
@@ -11,7 +11,7 @@ import pysat
 logger = logging.getLogger(__name__)
 
 
-def download(date_array, tag, sat_id, data_path=None, user=None,
+def download(date_array, tag, inst_id, data_path=None, user=None,
              password=None):
     """ Download
 
@@ -22,7 +22,7 @@ def download(date_array, tag, sat_id, data_path=None, user=None,
     return
 
 
-def list_remote_files(tag, sat_id):
+def list_remote_files(tag, inst_id):
     """Lists files available for Demeter.
 
     Note
@@ -36,7 +36,7 @@ def list_remote_files(tag, sat_id):
     tag : string or NoneType
         Denotes type of file to load.  Accepted types are <tag strings>.
         (default=None)
-    sat_id : string or NoneType
+    inst_id : string or NoneType
         Specifies the satellite ID for a constellation.  Not used.
         (default=None)
 

--- a/pysatIncubator/instruments/superdarn_grdex.py
+++ b/pysatIncubator/instruments/superdarn_grdex.py
@@ -47,7 +47,7 @@ platform = 'superdarn'
 name = 'grdex'
 tags = {'north': '',
         'south': ''}
-sat_ids = {'': ['north', 'south']}
+inst_ids = {'': ['north', 'south']}
 _test_dates = {'': {'north': dt.datetime(2009, 1, 1),
                     'south': dt.datetime(2009, 1, 1)}}
 _test_download = {'': {kk: False for kk in tags.keys()}}
@@ -91,7 +91,7 @@ def init(self):
     return
 
 
-def list_remote_files(tag, sat_id, data_path=None, format_str=None):
+def list_remote_files(tag, inst_id, data_path=None, format_str=None):
     """Lists remote files available for SuperDARN.
 
     Note
@@ -105,7 +105,7 @@ def list_remote_files(tag, sat_id, data_path=None, format_str=None):
     tag : string or NoneType
         Denotes type of file to load.  Accepted types are <tag strings>.
         (default=None)
-    sat_id : string or NoneType
+    inst_id : string or NoneType
         Specifies the satellite ID for a constellation.  Not used.
         (default=None)
 
@@ -138,7 +138,7 @@ def list_remote_files(tag, sat_id, data_path=None, format_str=None):
     # the init function above is used to reset the
     # lost_remote_files method with one where the
     # data path and format_str are set
-    local_files = list_files(tag, sat_id, data_path, format_str)
+    local_files = list_files(tag, inst_id, data_path, format_str)
     # iterating directly since pandas is complaining about periods
     # between different between indexes
     for time, fname in local_files.iteritems():
@@ -146,7 +146,7 @@ def list_remote_files(tag, sat_id, data_path=None, format_str=None):
     return remote_files
 
 
-def list_files(tag='north', sat_id=None, data_path=None, format_str=None):
+def list_files(tag='north', inst_id=None, data_path=None, format_str=None):
     """Return a Pandas Series of every file for chosen satellite data
 
     Parameters
@@ -154,7 +154,7 @@ def list_files(tag='north', sat_id=None, data_path=None, format_str=None):
     tag : string
         Denotes type of file to load.  Accepted types are 'north' and 'south'.
         (default='north')
-    sat_id : string or NoneType
+    inst_id : string or NoneType
         Specifies the satellite ID for a constellation.  Not used.
         (default=None)
     data_path : string or NoneType
@@ -187,7 +187,7 @@ def list_files(tag='north', sat_id=None, data_path=None, format_str=None):
         return pysat.Files.from_os(data_path=data_path, format_str=format_str)
 
 
-def load(fnames, tag=None, sat_id=None):
+def load(fnames, tag=None, inst_id=None):
     import davitpy
     if len(fnames) <= 0:
         return pds.DataFrame(None), pysat.Meta(None)
@@ -274,7 +274,7 @@ def clean(self):
     return
 
 
-def download(date_array, tag, sat_id, data_path, user=None, password=None):
+def download(date_array, tag, inst_id, data_path, user=None, password=None):
     """
     Download SuperDARN data from Virginia Tech organized for loading by pysat.
 

--- a/pysatIncubator/instruments/supermag_magnetometer.py
+++ b/pysatIncubator/instruments/supermag_magnetometer.py
@@ -54,7 +54,7 @@ tags = {'indices': 'SMU and SML indices',
         '': 'magnetometer measurements',
         'all': 'magnetometer measurements and indices',
         'stations': 'magnetometer stations'}
-sat_ids = {'': tags.keys()}
+inst_ids = {'': tags.keys()}
 _test_dates = {'': {kk: dt.datetime(2009, 1, 1) for kk in tags.keys()}}
 _test_download = {'': {kk: False for kk in tags.keys()}}
 
@@ -95,7 +95,7 @@ def init(self):
     return
 
 
-def list_remote_files(tag='', sat_id=None, data_path=None, format_str=None,
+def list_remote_files(tag='', inst_id=None, data_path=None, format_str=None,
                       year=None, month=None, Day=None):
     """Lists remote files available for SuperMAG.
 
@@ -113,7 +113,7 @@ def list_remote_files(tag='', sat_id=None, data_path=None, format_str=None,
         Denotes type of file to load.  Accepted types are 'indices', 'all',
         'stations', and '' (for just magnetometer measurements).
         (default='')
-    sat_id : string or NoneType
+    inst_id : string or NoneType
         Specifies the satellite ID for a constellation.  Not used.
         (default=None)
     data_path : string or NoneType
@@ -172,13 +172,13 @@ def list_remote_files(tag='', sat_id=None, data_path=None, format_str=None,
     # data path and format_str are set
     # iterating directly since pandas is complaining about periods
     # between different between indexes
-    local_files = list_files(tag, sat_id, data_path, format_str)
+    local_files = list_files(tag, inst_id, data_path, format_str)
     for time, fname in local_files.iteritems():
         remote_files.loc[time] = fname
     return remote_files
 
 
-def list_files(tag='', sat_id=None, data_path=None, format_str=None):
+def list_files(tag='', inst_id=None, data_path=None, format_str=None):
     """Return a Pandas Series of every file for chosen SuperMAG data
 
     Parameters
@@ -186,7 +186,7 @@ def list_files(tag='', sat_id=None, data_path=None, format_str=None):
     tag : string
         Denotes type of file to load.  Accepted types are 'indices', 'all',
         'stations', and '' (for just magnetometer measurements). (default='')
-    sat_id : string or NoneType
+    inst_id : string or NoneType
         Specifies the satellite ID for a constellation.  Not used.
         (default=None)
     data_path : string or NoneType
@@ -252,7 +252,7 @@ def list_files(tag='', sat_id=None, data_path=None, format_str=None):
         return pysat.Files.from_os(data_path=data_path, format_str=format_str)
 
 
-def load(fnames, tag='', sat_id=None):
+def load(fnames, tag='', inst_id=None):
     """ Load the SuperMAG files
 
     Parameters
@@ -262,7 +262,7 @@ def load(fnames, tag='', sat_id=None):
     tag : str
         Denotes type of file to load.  Accepted types are 'indices', 'all',
         'stations', and '' (for just magnetometer measurements). (default='')
-    sat_id : str or NoneType
+    inst_id : str or NoneType
         Satellite ID for constellations, not used. (default=None)
 
     Returns
@@ -690,7 +690,7 @@ def clean(supermag):
     return
 
 
-def download(date_array, tag, sat_id, data_path):
+def download(date_array, tag, inst_id, data_path):
     """Routine to download SuperMAG data
 
     Parameters


### PR DESCRIPTION
Addresses pysat/pysat#473, test with pysat/pysat#556

Updates use of `sat_id` to `inst_id`.

Passing locally with the `break/inst_id` branch of pysat.  Expected to fail on Travis until pysat/pysat#556 is merged.