### PR TITLE
MAINT: unit test standards

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,11 +12,11 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.8, 3.9]
+        python-version: ["3.8", "3.9"]
         numpy_ver: [latest]
         include:
-          - python-version: 3.7
-            numpy_ver: 1.17
+          - python-version: "3.7"
+            numpy_ver: "1.18"
             os: ubuntu-latest
 
     name: Python ${{ matrix.python-version }} on ${{ matrix.os }} with numpy ${{ matrix.numpy_ver }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,12 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [0.x.y] - 2021-05-7
-- Added pyglow interface, migrated from pysatMissions
-- Update metadata standards
-- Migrate CI tests to github actions
+* Added `pyglow` interface, migrated from `pysatMissions`
+* Update metadata standards
+* Migrate CI tests to Github Actions
+* Maintenance
+  * Update test instrument with `num_samples` keyword
+  * Update docstring standards in tests
 
 ## [0.0.1] - 2020-08-13
-- initial port of existing routines from pysat
+* initial port of existing routines from `pysat`

--- a/pysatIncubator/tests/test_instruments.py
+++ b/pysatIncubator/tests/test_instruments.py
@@ -1,3 +1,11 @@
+"""Unit and Integration Tests for each instrument module.
+
+Note
+----
+Imports test methods from pysat.tests.instrument_test_class
+
+"""
+
 import tempfile
 
 import pytest
@@ -40,9 +48,19 @@ for method in method_list:
 
 
 class TestInstruments(InstTestClass):
+    """Main class for instrument tests.
+
+    Note
+    ----
+    Uses class level setup and teardown so that all tests use the same
+    temporary directory. We do not want to geneate a new tempdir for each test,
+    as the load tests need to be the same as the download tests.
+
+    """
 
     def setup_class(self):
-        """Runs once before the tests to initialize the testing setup."""
+        """Initialize the testing setup once before all tests are run."""
+
         # Make sure to use a temporary directory so that the user's setup is not
         # altered
         self.tempdir = tempfile.TemporaryDirectory()
@@ -52,15 +70,12 @@ class TestInstruments(InstTestClass):
         # to point to their own subpackage location, e.g.,
         # self.inst_loc = mypackage.instruments
         self.inst_loc = pysatIncubator.instruments
+        return
 
     def teardown_class(self):
-        """Runs after every method to clean up previous testing."""
+        """Clean up downloaded files and parameters from tests."""
+
         pysat.params.data['data_dirs'] = self.saved_path
         self.tempdir.cleanup()
-        del self.inst_loc, self.saved_path, self.tempdir
-
-    def setup_method(self):
-        """Runs before every method to create a clean testing setup."""
-
-    def teardown_method(self):
-        """Runs after every method to clean up previous testing."""
+        del self.inst_loc, self.saved_path, self.tempdir, self.stime
+        return

--- a/pysatIncubator/tests/test_instruments.py
+++ b/pysatIncubator/tests/test_instruments.py
@@ -77,5 +77,5 @@ class TestInstruments(InstTestClass):
 
         pysat.params.data['data_dirs'] = self.saved_path
         self.tempdir.cleanup()
-        del self.inst_loc, self.saved_path, self.tempdir, self.stime
+        del self.inst_loc, self.saved_path, self.tempdir
         return

--- a/pysatIncubator/tests/test_methods_empirical.py
+++ b/pysatIncubator/tests/test_methods_empirical.py
@@ -89,4 +89,3 @@ class TestBasics():
             assert target in self.testInst.meta.data.index
         return
 
-    # TODO: Add hwm tests once routine is generalized

--- a/pysatIncubator/tests/test_methods_empirical.py
+++ b/pysatIncubator/tests/test_methods_empirical.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Test some of the pyglow method functions
+"""Test some of the pyglow method functions."""
 
 import datetime as dt
 import numpy as np
@@ -12,19 +12,32 @@ from pysatIncubator.methods import empirical as mm_emp
 
 
 class TestBasics():
+    """Main unit tests for pyglow methods to add empirical models.
+
+    Note
+    ----
+    Currently skipped in CI environments due to issues with installing pyglow
+    on github actions.
+    """
+
     def setup(self):
-        """Runs before every method to create a clean testing setup."""
+        """Create a clean testing setup before each method."""
+
         if (os.environ.get('CI') == 'true'):
             pytest.skip('pyglow tests skipped on CI')
         self.testInst = pysat.Instrument(platform='pysat', name='testing',
                                          num_samples=100, clean_level='clean')
+        return
 
     def teardown(self):
-        """Clean up test environment after tests"""
+        """Clean up test environment after each method."""
+
         del self
+        return
 
     def test_add_iri_thermal_plasma(self):
-        """Test adding thermal plasma data to test inst"""
+        """Test adding thermal plasma data to test inst."""
+
         self.testInst.custom_attach(mm_emp.add_iri_thermal_plasma,
                                     kwargs={'glat_label': 'latitude',
                                             'glong_label': 'longitude',
@@ -38,9 +51,11 @@ class TestBasics():
             assert not np.isnan(self.testInst[target]).any()
             # Check if metadata is added
             assert target in self.testInst.meta.data.index
+        return
 
     def test_add_igrf(self):
-        """Test adding igrf model to test inst"""
+        """Test adding igrf model to test inst."""
+
         self.testInst.custom_attach(mm_emp.add_igrf,
                                     kwargs={'glat_label': 'latitude',
                                             'glong_label': 'longitude',
@@ -54,9 +69,11 @@ class TestBasics():
             assert not np.isnan(self.testInst[target]).any()
             # Check if metadata is added
             assert target in self.testInst.meta.data.index
+        return
 
     def test_add_msis(self):
-        """Test adding msis model to test inst"""
+        """Test adding msis model to test inst."""
+
         self.testInst.custom_attach(mm_emp.add_msis,
                                     kwargs={'glat_label': 'latitude',
                                             'glong_label': 'longitude',
@@ -70,5 +87,6 @@ class TestBasics():
             assert not np.isnan(self.testInst[target]).any()
             # Check if metadata is added
             assert target in self.testInst.meta.data.index
+        return
 
     # TODO: Add hwm tests once routine is generalized

--- a/pysatIncubator/tests/test_methods_empirical.py
+++ b/pysatIncubator/tests/test_methods_empirical.py
@@ -88,4 +88,3 @@ class TestBasics():
             # Check if metadata is added
             assert target in self.testInst.meta.data.index
         return
-

--- a/pysatIncubator/tests/test_methods_empirical.py
+++ b/pysatIncubator/tests/test_methods_empirical.py
@@ -17,7 +17,7 @@ class TestBasics():
         if (os.environ.get('CI') == 'true'):
             pytest.skip('pyglow tests skipped on CI')
         self.testInst = pysat.Instrument(platform='pysat', name='testing',
-                                         inst_id='100', clean_level='clean')
+                                         num_samples=100, clean_level='clean')
 
     def teardown(self):
         """Clean up test environment after tests"""

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,6 +47,8 @@ omit =
 [flake8]
 max-line-length = 80
 ignore =
+  D200
+  D202
   W503
 exclude =
   docs/conf.py


### PR DESCRIPTION
Updates the unit test area, including:
- use of `num_samples` keyword
- docstring standards
- return statements

Also updates the workflow to use numpy 1.18 as the minimum test version